### PR TITLE
fix: Add setup_version and dependency to module.xml

### DIFF
--- a/GeoFencing/etc/acl.xml
+++ b/GeoFencing/etc/acl.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
+    <acl>
+        <resources>
+            <resource id="Magento_Backend::admin">
+                <resource id="Magento_Backend::stores">
+                    <resource id="Magento_Backend::stores_settings">
+                        <resource id="Magento_Config::config">
+                            <resource id="AgriCart_GeoFencing::config_geofencing" title="GeoFencing Section" sortOrder="100" />
+                        </resource>
+                    </resource>
+                </resource>
+            </resource>
+        </resources>
+    </acl>
+</config>

--- a/GeoFencing/etc/module.xml
+++ b/GeoFencing/etc/module.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="AgriCart_GeoFencing"/>
+    <module name="AgriCart_GeoFencing" setup_version="1.0.4">
+        <sequence>
+            <module name="Magento_Config"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
This commit adds the setup_version and a sequence dependency on Magento_Config to the module.xml file. This is to ensure the module loads correctly and its admin configuration is visible, which can resolve issues where the config section does not appear.