### PR TITLE
test: Move config section to advanced tab

### DIFF
--- a/GeoFencing/etc/adminhtml/system.xml
+++ b/GeoFencing/etc/adminhtml/system.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:config:Magento_Config:etc/system_file.xsd">
     <system>
+        <!--
         <tab id="agricart" translate="label" sortOrder="100">
             <label>AgriCart</label>
         </tab>
-        <section id="geofencing" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
+        -->
+        <section id="geofencing" translate="label" type="text" sortOrder="200" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
-            <label>GeoFencing</label>
-            <tab>agricart</tab>
+            <label>GeoFencing (Diagnostic)</label>
+            <tab>advanced</tab>
             <resource>AgriCart_GeoFencing::config_geofencing</resource>
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Configuration</label>


### PR DESCRIPTION
This is a diagnostic commit to debug why the configuration section is not appearing.

The custom "AgriCart" tab has been temporarily removed, and the "GeoFencing" section has been moved under the standard "Advanced" tab. This will help determine if the issue is with the custom tab definition or the section itself.