### PR TITLE
test: Remove resource check from system.xml

### DIFF
--- a/GeoFencing/etc/adminhtml/system.xml
+++ b/GeoFencing/etc/adminhtml/system.xml
@@ -10,7 +10,7 @@
             <class>separator-top</class>
             <label>GeoFencing (Diagnostic)</label>
             <tab>advanced</tab>
-            <resource>AgriCart_GeoFencing::config_geofencing</resource>
+            <!-- <resource>AgriCart_GeoFencing::config_geofencing</resource> -->
             <group id="general" translate="label" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>General Configuration</label>
                 <field id="enable" translate="label" type="select" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
This is the final diagnostic step to debug the invisible configuration section.

By commenting out the `<resource>` tag, we remove the ACL permission check entirely. If the section appears now, the issue is with the ACL system. If it still does not appear, the issue is fundamental to the section definition.